### PR TITLE
Replace non-breaking spaces with regular spaces in selection handler

### DIFF
--- a/lib/term-view.js
+++ b/lib/term-view.js
@@ -9,6 +9,7 @@ import { Disposable, CompositeDisposable, Task } from 'atom';
 import { Emitter } from 'event-kit';
 
 const newElementResizeDetector = require('element-resize-detector');
+const prepareTextForClipboard = require('xterm/lib/handlers/Clipboard').prepareTextForClipboard;
 
 Terminal.loadAddon('fit');
 
@@ -173,7 +174,7 @@ class TermView {
       return this.emitter.emit('did-change-title', title);
     });
 
-    term.on('selection', ({ contents }) => atom.clipboard.write(contents));
+    term.on('selection', ({ contents }) => atom.clipboard.write(prepareTextForClipboard(contents)));
 
     term.on('focus', () => this.emitter.emit('focus'));
 


### PR DESCRIPTION
The contents of the xterm contain non-breaking spaces which can cause problems where regular spaces are expected. xterm already cleans these up for its clipboard handling so we can just import their function here and use it.