### PR TITLE
Use the correct command for copy context menu item

### DIFF
--- a/menus/xterm.cson
+++ b/menus/xterm.cson
@@ -20,7 +20,7 @@
   '.xterm': [
     {
       'label': 'Copy'
-      'command': 'xterm:copy'
+      'command': 'core:copy'
     }
     {
       'label': 'Paste'


### PR DESCRIPTION
The copy context menu item currently calls `xterm:copy` which does not seem to exist. This changes the menu item to call `core:copy` which works correctly as far as I can tell.