### PR TITLE
Fix ipython prompts: don't focus on input received

### DIFF
--- a/lib/term-view.js
+++ b/lib/term-view.js
@@ -101,7 +101,6 @@ class TermView {
       console.error(error);
     }
     this.resizeToPane();
-    this.focusTerm();
   }
 
   attached() {


### PR DESCRIPTION
IPython's python-prompt-toolkit asks for a "cursor position report" on every prompt, which looks like input to `atom-xterm` and causes it to steal focus from other panes. Example:
- Run `ipython` in xterm pane
- Run some slow-ish python computation
- Switch to editor pane
- Sometime later, while you're editing, the computation finishes and steals focus back over to ipython

Here's some rough code pointers in python-prompt-toolkit, for reference:
- https://github.com/jonathanslenders/python-prompt-toolkit/blob/4476b3c/prompt_toolkit/renderer.py#L357
- https://github.com/jonathanslenders/python-prompt-toolkit/blob/4476b3c/prompt_toolkit/terminal/vt100_output.py#L626
- https://github.com/jonathanslenders/python-prompt-toolkit/blob/4476b3c/prompt_toolkit/key_binding/bindings/basic.py#L204
- And a little discussion: https://github.com/ipython/ipython/issues/10416

The fix here is just to not `.focus()` when input is received. This assumes:
- If the user wants focus on the term pane then they already have it in focus
- If the user doesn't have the term pane in focus then they don't want that to change