### PR TITLE
Fix observeActivePaneItem: focus() -> focusTerm()

### DIFF
--- a/index.js
+++ b/index.js
@@ -302,7 +302,7 @@ export default {
     this.disposables.add(
       atom.workspace.observeActivePaneItem(item => {
         if (item instanceof TermView) {
-          item.focus();
+          item.focusTerm();
         }
       }),
     );


### PR DESCRIPTION
- Fixes 2 bugs:
  - Moving a term item such that another term item becomes exposes causes both to infinitely steal focus back and forth from each other, hanging the atom window
  - Moving a pane item such that a term item becomes exposed causes the term item to steal focus away from the newly moved pane item
- The problem is that `item.focus()` re-triggers `observeActivePaneItem`, which causes the focus stealing and, in the case of two term items, the infinite loop and hang
- Switching to `item.focusTerm()` appears to resolve the issue while keeping the desired functionality